### PR TITLE
Change mememagic dependecy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+### Problem:
+
+_TODO: a description of the story/issue the pr solves_
+
+### Solution:
+
+_TODO: how did you achieve it? what did you use?_
+
+### Notes:
+
+_TODO: anything that reviewers should know before reviewing?_
+
+### QC Notes:
+
+_TODO: What parts/flows of the app are affected by this change?_
+
+### Release steps:
+
+_TODO: steps needed for the release. If no special handling needed, please write 'Normal Release'_
+
+### Security:
+
+_TODO: Are the changes exposed publicly or internally?_
+
+_TODO: Do all new endpoints impose proper access to authorized users only?_
+
+### Network:
+
+_TODO: Link to Ops PR if any. Type N/A if none._
+
+_TODO: List new internal/external services communications that were introduced in this PR. Type N/A if none._
+
+
+### Author checklist:
+- [ ] Backward compatibility checked
+- [ ] Release steps added
+- [ ] Unit tests added (if code logic is touched)
+- [ ] JIRA ticket moved to Reviewing
+- [ ] Rebased to latest master
+- [ ] Commits are clean
+
+### Reviewer checklist:
+- [ ] Backward compatibility checked
+- [ ] Code quality is acceptable
+- [ ] Specs logic coverage
+- [ ] Commits are clean

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activemodel', '>= 3.0.0')
   s.add_dependency('activesupport', '>= 3.0.0')
   s.add_dependency('cocaine', '~> 0.5.3')
+  s.add_dependency('mimemagic', '~> 0.3.7')
   s.add_dependency('mime-types')
 
   s.add_development_dependency('activerecord', '>= 3.0.0')


### PR DESCRIPTION
Based on the recent events, MimeMagic is now sitting under its own org at https://github.com/mimemagicrb/mimemagic, and became MIT licensed.

https://rubygems.org/gems/mimemagic/versions/0.3.7